### PR TITLE
Fix <li> tag line-height

### DIFF
--- a/system/themes/default/styles.php
+++ b/system/themes/default/styles.php
@@ -51,7 +51,7 @@
     }
 
     li {
-        line-height: 0.5em;
+        line-height: 1.2em;
     }
 
     p {


### PR DESCRIPTION
Fixed indentation between lines when the text in the <li> tag is moved to the next line